### PR TITLE
edit regex tag value to allow @,trailing and leading spaces

### DIFF
--- a/CreateUIDefinition.json
+++ b/CreateUIDefinition.json
@@ -19,7 +19,6 @@
         "type": "Microsoft.Common.Section",
         "label": "Integration Configuration",
         "elements": [
-
           {
             "name": "isProd",
             "type": "Microsoft.Common.CheckBox",
@@ -71,15 +70,15 @@
                 },
                 {
                   "id": "tagValue",
-                  "header": "Tag Value", 
+                  "header": "Tag Value",
                   "width": "1fr",
                   "element": {
                     "type": "Microsoft.Common.TextBox",
                     "placeholder": "Production",
                     "constraints": {
                       "required": true,
-                      "regex": "^[a-zA-Z0-9_\\s-]+$",
-                      "validationMessage": "Tag value must contain only letters, numbers, spaces, underscores, and hyphens"
+                      "regex": "^[\\w\\s\\-./:@()]+$",
+                      "validationMessage": "Tag value may include letters, numbers, spaces, underscore (_), hyphen (-), dot (.), slash (/), colon (:), at (@), and parentheses"
                     }
                   }
                 }
@@ -166,11 +165,11 @@
             "name": "ffAccessKey",
             "type": "Microsoft.Common.PasswordBox",
             "label": {
-                "password": "Firefly Access Key",
-                "confirmPassword": "Re-enter Firefly Access Key"
+              "password": "Firefly Access Key",
+              "confirmPassword": "Re-enter Firefly Access Key"
             },
             "toolTip": "Enter your Firefly Access Key.",
-            "constraints": { 
+            "constraints": {
               "required": true,
               "regex": "^.+$",
               "validationMessage": "Firefly Access Key is required"
@@ -183,11 +182,11 @@
             "name": "ffSecretKey",
             "type": "Microsoft.Common.PasswordBox",
             "label": {
-                "password": "Firefly Secret Key",
-                "confirmPassword": "Re-enter Firefly Secret Key"
+              "password": "Firefly Secret Key",
+              "confirmPassword": "Re-enter Firefly Secret Key"
             },
             "toolTip": "Enter your Firefly Secret Key.",
-            "constraints": { 
+            "constraints": {
               "required": true,
               "regex": "^.+$",
               "validationMessage": "Firefly Secret Key is required"


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
- [ ] Bug fix
- [ ] Feature
- [ ] Code maintenance
- [V] Performance enhancement

* **Description of the changes included in this PR (In case of a bug fix, please highlight the expected behaviour vs the observed one)**
This PR updates the **Tag Value** regex in `CreateUIDefinition.json` to be more permissive and aligned with Azure’s rules.  
- Old: `^[a-zA-Z0-9_\s-]+$` (blocked `@`, `.`, `/`, `:` and parentheses)  
- New: `^[\w\s\-./:@()]+$` (allows spaces anywhere, plus `- . / : @ ()`) 

* **Does this PR introduce a breaking change?**
No. This change is backwards-compatible. Existing tag values remain valid, and more options are now accepted.


* **Please declare that your PR fulfills these requirements:**
- [ ] Unit tests covering my changes are included
- [V] I successfully ran my code on my local setup
- [ ] This branch has been successfully deployed in a development environment
- [V] My code follows the project's style guidelines and has been linted
- [ ] Documentation have been added / updated (please add a link)