### PR TITLE
fix: SHA-pin all 3rd-party GitHub Actions (supply chain hardening)

### DIFF
--- a/.github/workflows/firefly-gitleaks-check.yaml
+++ b/.github/workflows/firefly-gitleaks-check.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Install Gitleaks
         run: |
           wget https://github.com/gitleaks/gitleaks/releases/download/v8.18.2/gitleaks_8.18.2_linux_x64.tar.gz
@@ -33,7 +33,7 @@ jobs:
       - name: Send to Slack if sensitive data found
         if: steps.gitleaks.outputs.exitcode == 1
         id: slack-send
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # v2
         env:
           SLACK_ICON: https://avatars.slack-edge.com/2022-03-12/3228412958213_797a01c4347dd0e18e8f_102.png
           SLACK_COLOR: ${{ steps.gitleaks.outputs.exitcode == 1 && 'failure' || 'success'}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,18 +14,18 @@ jobs:
     environment: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Node 16
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 16
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@cf5f706ea817a201939cff62126e3c08b84879c7 # v2
         id: semantic
         with:
           semantic_version: 18.0.0


### PR DESCRIPTION
## Summary
Pin all 3rd-party action references to immutable SHA digests.

## Why
Mutable tags can be force-pushed by attackers to point at malicious commits (as happened with aquasecurity/trivy-action on 2026-03-19). SHA-pinned references are immutable and safe from this class of attack.

No functional changes -- all SHAs resolve to the same versions previously referenced by tag.