### PR TITLE
INFL-18616 fix: escape special characters in CreateUIDefinition dropdown displayNames

### DIFF
--- a/CreateUIDefinition-managementgroups.json
+++ b/CreateUIDefinition-managementgroups.json
@@ -43,7 +43,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => equals(i.type,'Microsoft.Management/managementGroups')),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> createObject('label', item.properties.displayName, 'value', item.name))]",
           "required": true
         },
         "visible": true
@@ -59,7 +59,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> createObject('label', item.properties.displayName, 'value', item.name))]",
           "required": true
         },
         "visible": true
@@ -111,9 +111,9 @@
         "filter": true,
         "multiselect": false,
         "selectAll": false,
-        "defaultValue": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
+        "defaultValue": "[map(basics('armrg').value, (item) => createObject('label', item.name, 'value', item.name))]",
         "constraints": {
-          "allowedValues": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(basics('armrg').value, (item) => createObject('label', item.name, 'value', item.name))]",
           "required": "[equals(basics('resourceGroupOption'), 'existing')]"
         },
         "visible": "[equals(basics('resourceGroupOption'), 'existing')]"

--- a/CreateUIDefinition.json
+++ b/CreateUIDefinition.json
@@ -127,7 +127,7 @@
             "placeholder": "Select subscriptions to monitor",
             "toolTip": "Select the subscriptions where you want to deploy Firefly monitoring infrastructure. Multi-subscription deployment will create the same monitoring infrastructure (storage account, event grid, diagnostic settings) in each selected subscription.",
             "constraints": {
-              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => parse(concat('{\"label\":\"', item.displayName, ' (', item.subscriptionId, ')\",\"value\":\"', item.subscriptionId, '\"}')))]",
+              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => createObject('label', concat(item.displayName, ' (', item.subscriptionId, ')'), 'value', item.subscriptionId))]",
               "required": true
             },
             "visible": true,


### PR DESCRIPTION
## Summary

The `CreateUIDefinition*.json` dropdowns (Target Subscriptions, Management Group, Subscription for Deployment, Existing Resource Group) were building their options by concatenating raw `displayName` / `name` values into a JSON string and then calling `parse(...)` on it:

```js
parse(concat('{"label":"', item.displayName, ' (', item.subscriptionId, ')","value":"', item.subscriptionId, '"}'))
```

This crashes the dropdown whenever a subscription / management-group / resource-group name contains a JSON-special character — most commonly a **backslash (`\`)** or **double quote (`"`)**, both of which Azure allows in displayNames. When `parse()` fails, the picker renders empty / errors out and the user cannot proceed with deployment.

This PR replaces the unsafe pattern with `createObject(...)`, which builds the option structurally so the runtime handles escaping for us. All characters Azure permits in those names are now safe.

## Changes

- `CreateUIDefinition.json` (1 occurrence): Target Subscriptions dropdown
- `CreateUIDefinition-managementgroups.json` (4 occurrences): Management Group, Subscription for Deployment, Existing Resource Group (`defaultValue` + `allowedValues`)

**Before**
```js
parse(concat('{"label":"', item.displayName, '","value":"', item.name, '"}'))
```

**After**
```js
createObject('label', item.displayName, 'value', item.name)
```

## Behavior change

- ✅ Same `value` selected by the user (subscriptionId / management-group name / resource-group name)
- ✅ Same `label` text shown in the dropdown
- ✅ ARM template parameters unchanged
- ✅ Names containing `\`, `"`, control chars, accents, slashes, etc. now render correctly instead of breaking the picker

## Verification

- Both JSON files validate (`json.load` succeeds)
- No `parse(concat(...))` patterns remain in either UI definition
- `git diff` shows only the 5 targeted line changes