### PR TITLE
INFL-18616 fix: escape backslashes and quotes in CreateUIDefinition dropdown displayNames

### DIFF
--- a/CreateUIDefinition-managementgroups.json
+++ b/CreateUIDefinition-managementgroups.json
@@ -43,7 +43,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => equals(i.type,'Microsoft.Management/managementGroups')),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> parse(concat('{\"label\":\"', replace(replace(item.properties.displayName, '\\', '\\\\'), '\"', '\\\"'), '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
           "required": true
         },
         "visible": true
@@ -59,7 +59,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', replace(replace(item.properties.displayName, '\\', '\\\\'), '\"', '\\\"'), '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
           "required": true
         },
         "visible": true
@@ -111,9 +111,9 @@
         "filter": true,
         "multiselect": false,
         "selectAll": false,
-        "defaultValue": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', replace(replace(item.name, '\\', '\\\\'), '\"', '\\\"'), '\",\"value\":\"', item.name, '\"}')))]",
+        "defaultValue": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
         "constraints": {
-          "allowedValues": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', replace(replace(item.name, '\\', '\\\\'), '\"', '\\\"'), '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
           "required": "[equals(basics('resourceGroupOption'), 'existing')]"
         },
         "visible": "[equals(basics('resourceGroupOption'), 'existing')]"

--- a/CreateUIDefinition-managementgroups.json
+++ b/CreateUIDefinition-managementgroups.json
@@ -43,7 +43,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => equals(i.type,'Microsoft.Management/managementGroups')),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> createObject('label', item.properties.displayName, 'value', item.name))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> parse(concat('{\"label\":\"', replace(replace(item.properties.displayName, '\\', '\\\\'), '\"', '\\\"'), '\",\"value\":\"', item.name, '\"}')))]",
           "required": true
         },
         "visible": true
@@ -59,7 +59,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> createObject('label', item.properties.displayName, 'value', item.name))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', replace(replace(item.properties.displayName, '\\', '\\\\'), '\"', '\\\"'), '\",\"value\":\"', item.name, '\"}')))]",
           "required": true
         },
         "visible": true
@@ -111,9 +111,9 @@
         "filter": true,
         "multiselect": false,
         "selectAll": false,
-        "defaultValue": "[map(basics('armrg').value, (item) => createObject('label', item.name, 'value', item.name))]",
+        "defaultValue": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', replace(replace(item.name, '\\', '\\\\'), '\"', '\\\"'), '\",\"value\":\"', item.name, '\"}')))]",
         "constraints": {
-          "allowedValues": "[map(basics('armrg').value, (item) => createObject('label', item.name, 'value', item.name))]",
+          "allowedValues": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', replace(replace(item.name, '\\', '\\\\'), '\"', '\\\"'), '\",\"value\":\"', item.name, '\"}')))]",
           "required": "[equals(basics('resourceGroupOption'), 'existing')]"
         },
         "visible": "[equals(basics('resourceGroupOption'), 'existing')]"

--- a/CreateUIDefinition-managementgroups.json
+++ b/CreateUIDefinition-managementgroups.json
@@ -43,7 +43,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => equals(i.type,'Microsoft.Management/managementGroups')),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> parse(concat('{\"label\":\"', replace(replace(item.properties.displayName, parse('\"\\\\\"'), parse('\"\\\\\\\\\"')), parse('\"\\\"\"'), parse('\"\\\\\\\"\"')), '\",\"value\":\"', item.name, '\"}')))]",
           "required": true
         },
         "visible": true
@@ -59,7 +59,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', replace(replace(item.properties.displayName, parse('\"\\\\\"'), parse('\"\\\\\\\\\"')), parse('\"\\\"\"'), parse('\"\\\\\\\"\"')), '\",\"value\":\"', item.name, '\"}')))]",
           "required": true
         },
         "visible": true
@@ -111,9 +111,9 @@
         "filter": true,
         "multiselect": false,
         "selectAll": false,
-        "defaultValue": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
+        "defaultValue": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', replace(replace(item.name, parse('\"\\\\\"'), parse('\"\\\\\\\\\"')), parse('\"\\\"\"'), parse('\"\\\\\\\"\"')), '\",\"value\":\"', item.name, '\"}')))]",
         "constraints": {
-          "allowedValues": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', replace(replace(item.name, parse('\"\\\\\"'), parse('\"\\\\\\\\\"')), parse('\"\\\"\"'), parse('\"\\\\\\\"\"')), '\",\"value\":\"', item.name, '\"}')))]",
           "required": "[equals(basics('resourceGroupOption'), 'existing')]"
         },
         "visible": "[equals(basics('resourceGroupOption'), 'existing')]"

--- a/CreateUIDefinition-managementgroups.json
+++ b/CreateUIDefinition-managementgroups.json
@@ -43,7 +43,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => equals(i.type,'Microsoft.Management/managementGroups')),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=> equals(i.type, 'Microsoft.Management/managementGroups')), (item)=> createObject('label', item.properties.displayName, 'value', item.name))]",
           "required": true
         },
         "visible": true
@@ -59,7 +59,7 @@
         "selectAll": false,
         "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
         "constraints": {
-          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> createObject('label', item.properties.displayName, 'value', item.name))]",
           "required": true
         },
         "visible": true
@@ -111,9 +111,9 @@
         "filter": true,
         "multiselect": false,
         "selectAll": false,
-        "defaultValue": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
+        "defaultValue": "[map(basics('armrg').value, (item) => createObject('label', item.name, 'value', item.name))]",
         "constraints": {
-          "allowedValues": "[map(basics('armrg').value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
+          "allowedValues": "[map(basics('armrg').value, (item) => createObject('label', item.name, 'value', item.name))]",
           "required": "[equals(basics('resourceGroupOption'), 'existing')]"
         },
         "visible": "[equals(basics('resourceGroupOption'), 'existing')]"

--- a/CreateUIDefinition.json
+++ b/CreateUIDefinition.json
@@ -127,7 +127,7 @@
             "placeholder": "Select subscriptions to monitor",
             "toolTip": "Select the subscriptions where you want to deploy Firefly monitoring infrastructure. Multi-subscription deployment will create the same monitoring infrastructure (storage account, event grid, diagnostic settings) in each selected subscription.",
             "constraints": {
-              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => parse(concat('{\"label\":\"', item.displayName, ' (', item.subscriptionId, ')\",\"value\":\"', item.subscriptionId, '\"}')))]",
+              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => createObject('label', concat(item.displayName, ' (', item.subscriptionId, ')'), 'value', item.subscriptionId))]",
               "required": true
             },
             "visible": true,

--- a/CreateUIDefinition.json
+++ b/CreateUIDefinition.json
@@ -127,7 +127,7 @@
             "placeholder": "Select subscriptions to monitor",
             "toolTip": "Select the subscriptions where you want to deploy Firefly monitoring infrastructure. Multi-subscription deployment will create the same monitoring infrastructure (storage account, event grid, diagnostic settings) in each selected subscription.",
             "constraints": {
-              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => parse(concat('{\"label\":\"', replace(replace(item.displayName, '\\', '\\\\'), '\"', '\\\"'), ' (', item.subscriptionId, ')\",\"value\":\"', item.subscriptionId, '\"}')))]",
+              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => parse(concat('{\"label\":\"', item.displayName, ' (', item.subscriptionId, ')\",\"value\":\"', item.subscriptionId, '\"}')))]",
               "required": true
             },
             "visible": true,

--- a/CreateUIDefinition.json
+++ b/CreateUIDefinition.json
@@ -127,7 +127,7 @@
             "placeholder": "Select subscriptions to monitor",
             "toolTip": "Select the subscriptions where you want to deploy Firefly monitoring infrastructure. Multi-subscription deployment will create the same monitoring infrastructure (storage account, event grid, diagnostic settings) in each selected subscription.",
             "constraints": {
-              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => createObject('label', concat(item.displayName, ' (', item.subscriptionId, ')'), 'value', item.subscriptionId))]",
+              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => parse(concat('{\"label\":\"', replace(replace(item.displayName, '\\', '\\\\'), '\"', '\\\"'), ' (', item.subscriptionId, ')\",\"value\":\"', item.subscriptionId, '\"}')))]",
               "required": true
             },
             "visible": true,

--- a/CreateUIDefinition.json
+++ b/CreateUIDefinition.json
@@ -127,7 +127,7 @@
             "placeholder": "Select subscriptions to monitor",
             "toolTip": "Select the subscriptions where you want to deploy Firefly monitoring infrastructure. Multi-subscription deployment will create the same monitoring infrastructure (storage account, event grid, diagnostic settings) in each selected subscription.",
             "constraints": {
-              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => parse(concat('{\"label\":\"', item.displayName, ' (', item.subscriptionId, ')\",\"value\":\"', item.subscriptionId, '\"}')))]",
+              "allowedValues": "[map(steps('integrationConfig').subscriptionApi.value, (item) => parse(concat('{\"label\":\"', replace(replace(item.displayName, parse('\"\\\\\"'), parse('\"\\\\\\\\\"')), parse('\"\\\"\"'), parse('\"\\\\\\\"\"')), ' (', item.subscriptionId, ')\",\"value\":\"', item.subscriptionId, '\"}')))]",
               "required": true
             },
             "visible": true,


### PR DESCRIPTION
## Jira

[INFL-18616](https://infralight1.atlassian.net/browse/INFL-18616)

## Bug

Azure subscription / management-group / resource-group displayNames containing a backslash (`\`) or double-quote (`"`) break the dropdowns in the deploy UI. The existing `parse(concat('{...}'))` pattern injects the name as raw text into a JSON string literal — a `\` or `"` in the name produces invalid JSON, `parse()` fails for the entire array, and the dropdown renders empty.

Critically, this blocks the entire tenant — not just the affected subscription.

**Reproduction**: rename any subscription to e.g. `_BTS Sandbox \ Dev/Test \ TEMP Resources Only!`. The Target Subscriptions dropdown shows "No available items" for every subscription in the tenant.

## Fix

Escape `\` → `\\` and `"` → `\"` in the displayName before concatenating it into the JSON literal.

The non-obvious challenge: the CreateUIDefinition expression DSL has no documented mechanism to put a literal backslash or double-quote in a single-quoted string literal. Inline `'\\'` and `'\"'` crash the expression parser and bring down the entire UI extension. (Confirmed by the official docs at https://learn.microsoft.com/en-us/azure/azure-resource-manager/managed-applications/create-ui-definition-string-functions and direct testing in the sandbox — also a known issue across the broader Microsoft expression language family, see https://stackoverflow.com/questions/54381014.)

The workaround used here: build the literals via `parse()`, which uses the documented JSON escape rules.
- `parse('"\\\\"')` → single-character `\` string
- `parse('"\\""')` → single-character `"` string

These are then passed as the search/replacement arguments to `replace()`. The escape happens on each item just before injection into the JSON literal, then the outer `parse()` reads valid JSON regardless of the original displayName content.

```js
// Before (vulnerable)
parse(concat('{"label":"', item.displayName, '"...}'))

// After (escapes \ and " safely; backslash literals never appear in source)
parse(concat('{"label":"',
  replace(replace(item.displayName,
    parse('"\\\\"'),  parse('"\\\\\\\\"')),  // \  -> \\
    parse('"\\""'),   parse('"\\\\\\""')),    // "  -> \"
  '"...}'))
```

## Validation

End-to-end tested in the **Azure CreateUIDefinition Sandbox** before opening this PR:

1. **Function-level**: `parse('"\\\\"')` returns a working single-character backslash; `contains()` and `replace()` accept it correctly.
2. **Pattern-level**: a synthetic 3-element dataset (item with `\`, normal item, item with `"`) renders correctly:
   - `_BTS Sandbox \ Dev/Test \ TEMP Resources Only! (sub-with-backslash)`
   - `normal sub (sub-normal)`
   - `name with "quote" (sub-with-quote)`

All three appear in the dropdown with the special characters preserved verbatim in the label.

## Changes

5 dropdown sites, 5 lines changed:

- `CreateUIDefinition.json` — Target Subscriptions
- `CreateUIDefinition-managementgroups.json`:
  - Management Group
  - Subscription for Deployment
  - Existing Resource Group `defaultValue`
  - Existing Resource Group `allowedValues`

## Behavior

- Same `value` selected (subscriptionId / MG name / RG name) — unchanged
- Same `label` text shown — preserved verbatim, including any backslashes/quotes in the source name
- ARM template parameters unchanged
- Names without special chars: identical behavior to `main`
- Names with `\` or `"`: dropdown now renders correctly instead of going empty

## History

Supersedes #20 (closed: branch-name compliance) and #21 (closed: previous fix attempts using `createObject` and inline `'\\'` both broke the templates differently). Detailed forensic record in INFL-18616.

[INFL-18616]: https://infralight1.atlassian.net/browse/INFL-18616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ